### PR TITLE
resolve undefined symbols error

### DIFF
--- a/crypto/secp256k1/panic_cb.go
+++ b/crypto/secp256k1/panic_cb.go
@@ -13,10 +13,12 @@ import "unsafe"
 // Callbacks for converting libsecp256k1 internal faults into
 // recoverable Go panics.
 
+//export secp256k1GoPanicIllegal
 func secp256k1GoPanicIllegal(msg *C.char, data unsafe.Pointer) {
 	panic("illegal argument: " + C.GoString(msg))
 }
 
+//export secp256k1GoPanicError
 func secp256k1GoPanicError(msg *C.char, data unsafe.Pointer) {
 	panic("internal error: " + C.GoString(msg))
 }


### PR DESCRIPTION
Fixes this error from pax from this test, https://github.com/paxosglobal/pax/pull/38982/files#diff-a0db6b63bb16890cf960faeda1b753db126e4b560b2bbb94dd29066ca2b5e4f1
```
Undefined symbols for architecture arm64:
  "_secp256k1GoPanicError", referenced from:
      _runtime.data in go.o
  "_secp256k1GoPanicIllegal", referenced from:
      _runtime.data in go.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```