### PR TITLE
CHAINS-0: crypto/secp256k1: restore //export directives on panic callbacks

### DIFF
--- a/crypto/secp256k1/panic_cb.go
+++ b/crypto/secp256k1/panic_cb.go
@@ -13,10 +13,12 @@ import "unsafe"
 // Callbacks for converting libsecp256k1 internal faults into
 // recoverable Go panics.
 
+//export secp256k1GoPanicIllegal
 func secp256k1GoPanicIllegal(msg *C.char, data unsafe.Pointer) {
 	panic("illegal argument: " + C.GoString(msg))
 }
 
+//export secp256k1GoPanicError
 func secp256k1GoPanicError(msg *C.char, data unsafe.Pointer) {
 	panic("internal error: " + C.GoString(msg))
 }


### PR DESCRIPTION
The //export directives on secp256k1GoPanicIllegal and secp256k1GoPanicError were removed to avoid duplicate C symbol definitions when multiple go-ethereum forks (go-ethereum, go-ethereum-arbitrum, go-ethereum-optimism) were linked into the same Bazel go_library target.

Without //export, these Go functions are not visible to the C linker, but the CGO preamble in secp256.go still declares them as extern:

    extern void secp256k1GoPanicIllegal(const char* msg, void* data);
    extern void secp256k1GoPanicError(const char* msg, void* data);

This causes "undefined reference to 'secp256k1GoPanicError'" linker failures in Bazel when this fork is compiled standalone (i.e., not linked alongside upstream go-ethereum which still has //export).

The original duplicate symbol problem has been resolved in the pax monorepo by splitting EVM entity converter packages into per-chain sub-packages, so each Bazel go_library target only depends on a single go-ethereum fork. With that fix in place, //export can be safely restored.